### PR TITLE
fix enum bindings for optimized builds

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2280,13 +2280,13 @@ var LibraryEmbind = {
     var shift = getShiftFromSize(size);
     name = readLatin1String(name);
 
-    function constructor() {
+    function ctor() {
     }
-    constructor.values = {};
+    ctor.values = {};
 
     registerType(rawType, {
         name: name,
-        constructor: constructor,
+        constructor: ctor,
         'fromWireType': function(c) {
             return this.constructor.values[c];
         },
@@ -2297,7 +2297,7 @@ var LibraryEmbind = {
         'readValueFromPointer': enumReadValueFromPointer(name, shift, isSigned),
         destructorFunction: null,
     });
-    exposePublicSymbol(name, constructor);
+    exposePublicSymbol(name, ctor);
   },
 
   _embind_register_enum_value__deps: [


### PR DESCRIPTION
This is fixing the problem with enum construction.
Here's an example.
1. clone this repo:
https://github.com/achoudhury85/Embind-Enum-Registration-Issue/
2. checkout and activate emscripten incoming
3. build it with `emcc --std=c++11 --bind -O3 main.cpp -o main.html`
4. load main.html:
```javascript
Module.Enum2
Window() { [native code] }
Module.Enum1
Window() { [native code] }
```

Please note that `function constructor` is missing here.
As the result, all enum values from all enums are squashed inside window prototype.

`function constructor() {}` is cut somewhere by optimizer because if we build with `-O0` this doesn't happen.